### PR TITLE
Added custom transformers for Day 1 pipeline (Himesh Patel)

### DIFF
--- a/custom_definitions.py
+++ b/custom_definitions.py
@@ -537,3 +537,119 @@ class MushroomFeatureCleaner(BaseEstimator, TransformerMixin):
             
         return X_transformed
 
+#=====================Himeshpatel================================#=======================================================
+import pandas as pd
+import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.cluster import KMeans
+from itertools import combinations
+from sklearn.pipeline import Pipeline
+
+
+class CustomFeatureEngineer(BaseEstimator, TransformerMixin):
+    def __init__(self, top_features=None):
+        self.top_features = top_features if top_features else []
+
+    def fit(self, X, y=None):
+        return self
+
+    def transform(self, X):
+        X = X.copy()
+        X[['feature_8', 'feature_15']] = X['feature_8,feature_15'].str.split(",", expand=True)
+        X[['feature_21', 'feature_10']] = X['feature_21,feature_10'].str.split(",", expand=True)
+        X[['feature_1', 'feature_6']] = X['feature_1,feature_6'].str.split(",", expand=True)
+        X.drop(['feature_8,feature_15', 'feature_21,feature_10', 'feature_1,feature_6'], axis=1, inplace=True)
+
+        string_cols = X.select_dtypes(include='object').columns
+        for col in string_cols:
+            X[col] = X[col].str.lower().str.strip()
+
+        return X
+
+class FeatureCombiner(BaseEstimator, TransformerMixin):
+    def __init__(self, top_features=None):
+        self.top_features = top_features if top_features else []
+
+    def fit(self, X, y=None):
+        return self
+
+    def transform(self, X):
+        X = X.copy()
+        for f1, f2 in combinations(self.top_features, 2):
+            new_col = f"{f1}_{f2}_comb"
+            X[new_col] = X[f1].astype(str) + "_" + X[f2].astype(str)
+
+        X["count_U"] = (X[self.top_features] == "U").sum(axis=1)
+        X["unique_top_cats"] = X[self.top_features].nunique(axis=1)
+        return X
+
+class ImputerWrapper(BaseEstimator, TransformerMixin):
+    def __init__(self):
+        self.imputer = SimpleImputer(strategy="constant")
+
+    def fit(self, X, y=None):
+        self.imputer.fit(X)
+        self.columns = X.columns
+        return self
+
+    def transform(self, X):
+        return pd.DataFrame(self.imputer.transform(X), columns=self.columns, index=X.index)
+
+
+class OneHotEncoderWrapper(BaseEstimator, TransformerMixin):
+    def __init__(self):
+        self.encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+
+    def fit(self, X, y=None):
+        self.obj_cols = X.select_dtypes(include="object").columns
+        self.encoder.fit(X[self.obj_cols])
+        return self
+
+    def transform(self, X):
+        X = X.copy()
+        encoded = self.encoder.transform(X[self.obj_cols])
+        encoded_df = pd.DataFrame(encoded, columns=self.encoder.get_feature_names_out(self.obj_cols), index=X.index)
+        return pd.concat([X.drop(columns=self.obj_cols), encoded_df], axis=1)
+
+
+class KMeansClusterWrapper(BaseEstimator, TransformerMixin):
+    def __init__(self, n_clusters=5):
+        self.n_clusters = n_clusters
+        self.kmeans = KMeans(n_clusters=n_clusters, random_state=42)
+
+    def fit(self, X, y=None):
+        self.kmeans.fit(X)
+        return self
+
+    def transform(self, X):
+        cluster_labels = self.kmeans.predict(X)
+        return pd.concat([X.reset_index(drop=True), pd.Series(cluster_labels, name="cluster_label")], axis=1)
+
+
+class ScalerWrapper(BaseEstimator, TransformerMixin):
+    def __init__(self):
+        self.scaler = StandardScaler()
+
+    def fit(self, X, y=None):
+        self.scaler.fit(X)
+        return self
+
+    def transform(self, X):
+        return self.scaler.transform(X)
+
+
+def create_pipeline():
+    top_features = ["feature_18", "feature_1"]
+    pipeline = Pipeline([
+        ("custom_feature_engineering", CustomFeatureEngineer(top_features=top_features)),
+        ("feature_combination", FeatureCombiner(top_features=top_features)),
+        ("imputation", ImputerWrapper()),
+        ("onehot_encode", OneHotEncoderWrapper()),
+        ("clustering", KMeansClusterWrapper()),
+        ("scaling", ScalerWrapper())
+    ])
+    return pipeline
+
+#=======================================================================================


### PR DESCRIPTION
This pull request adds custom transformer classes used in my Day 1 submission pipeline.

All definitions are appended at the end of custom_definitions.py as per the competition rules. These include:
- CustomFeatureEngineer
- FeatureCombiner
- ImputerWrapper
- OneHotEncoderWrapper
- KMeansClusterWrapper
- ScalerWrapper
- create_pipeline() function

These are necessary to ensure my .pkl model file loads correctly during evaluation.

Thank you for reviewing.